### PR TITLE
Support http health check request_path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,8 @@ resource "google_compute_health_check" "http" {
   name    = "${var.name}-hc"
 
   http_health_check {
-    port = "${var.health_port}"
+    port = "${var.health_port}",
+    request_path = "${var.http_health_check_request_path}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,10 @@ variable health_port {
   description = "Port to perform health checks on."
 }
 
+variable http_health_check_request_path {
+  description = "Request path to perform http health check on."
+}
+
 variable source_tags {
   description = "List of source tags for traffic between the internal load balancer."
   type        = "list"


### PR DESCRIPTION
Hello!

I'm building here on the recent addition of support for http health checks. Namely, I'm adding a variable to specify the path at which to perform the http health check (as [terraform-google-lb-http](https://github.com/GoogleCloudPlatform/terraform-google-lb-http) supports).

This seemed like the minimal change to achieve this functionality. I can see the argument for doing some refactoring and accepting a `backend_params` array instead as is the case with [terraform-google-lb-http](https://github.com/GoogleCloudPlatform/terraform-google-lb-http/blob/master/variables.tf#L47). Let me know how you'd like to proceed.

Thanks,
Matt