### PR TITLE
Added possibility to give a specific host to health-check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ resource "google_compute_health_check" "http" {
 
   http_health_check {
     port = "${var.health_port}"
+    host = "${var.host}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable backends {
   type        = "list"
 }
 
+variable host {
+  description = "HTTP header containing the host to reach for the http check, leave blank to use default value"
+  type       = "string"
+  default    = ""
+}
+
 variable session_affinity {
   description = "The session affinity for the backends example: NONE, CLIENT_IP. Default is `NONE`."
   default     = "NONE"


### PR DESCRIPTION
Added the host variable to "google_compute_http_health_check" and the string variable host to the variable file.

This will allow the user to specify a host header during health_check.