### PR TITLE
Allow setting region without updating provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ data "google_compute_network" "network" {
 data "google_compute_subnetwork" "network" {
   name    = var.subnetwork
   project = var.network_project == "" ? var.project : var.network_project
+  region  = var.region
 }
 
 resource "google_compute_forwarding_rule" "default" {


### PR DESCRIPTION
Same problem as https://github.com/terraform-google-modules/terraform-google-vm/pull/42 but for the ILB module:

Currently if we work in a specific region we'll have to specify it in our google provider.
This change allows to keep a region-agnostic provider and simply pass the region to the data.google_compute_zones.available resource.