### PR TITLE
Adding request parameter for tcp health checks.

### DIFF
--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-foundation-cicd/cft/developer-tools:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  id: 'lint'
+- id: 'lint'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/usr/local/bin/test_lint.sh']
 tags:
 - 'ci'

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -39,6 +39,7 @@ locals {
     healthy_threshold   = 4
     timeout_sec         = 1
     unhealthy_threshold = 5
+    request             = ""
     response            = "I AM HEALTHY"
     proxy_header        = "NONE"
     port                = 8081

--- a/examples/simple/locals.tf
+++ b/examples/simple/locals.tf
@@ -25,6 +25,7 @@ locals {
     healthy_threshold   = 4
     timeout_sec         = 1
     unhealthy_threshold = 5
+    request             = ""
     response            = "I AM HEALTHY"
     proxy_header        = "NONE"
     port                = 80

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,7 @@ resource "google_compute_health_check" "tcp" {
 
   tcp_health_check {
     port         = var.health_check["port"]
+    request      = var.health_check["request"]
     response     = var.health_check["response"]
     port_name    = var.health_check["port_name"]
     proxy_header = var.health_check["proxy_header"]

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,7 @@ variable "health_check" {
     healthy_threshold   = number
     timeout_sec         = number
     unhealthy_threshold = number
+    request             = string
     response            = string
     proxy_header        = string
     port                = number


### PR DESCRIPTION
Currently there is no way to configure the request string, which makes TCP health checks unusable.
Unfortunately, the health_check variable was declared as a single object for both http and tcp health checks, and there is no way to declare default values for individual object attributes. This will require adding an empty request parameter in cases where it is not needed (in http health checks).