### PR TITLE
Allow internal tcp load balancers on all ports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "google_compute_forwarding_rule" "default" {
   ip_address            = var.ip_address
   ip_protocol           = var.ip_protocol
   ports                 = var.ports
+  all_ports             = var.all_ports
   service_label         = var.service_label
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,8 @@ output "ip_address" {
   description = "The internal IP assigned to the regional forwarding rule."
   value       = google_compute_forwarding_rule.default.ip_address
 }
+
+output "forwrding_rule" {
+  description = "The forwarding rule self_link."
+  value       = google_compute_forwarding_rule.default.self_link
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "ip_address" {
   value       = google_compute_forwarding_rule.default.ip_address
 }
 
-output "forwrding_rule" {
+output "forwarding_rule" {
   description = "The forwarding rule self_link."
   value       = google_compute_forwarding_rule.default.self_link
 }

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "ports" {
   type        = list(string)
 }
 
+variable "all_ports" {
+  description = "Boolean for all_ports setting on forwarding rule."
+  type        = bool
+  default     = null
+}
+
 variable "health_check" {
   description = "Health check to determine whether instances are responsive and able to do work"
   type = object({


### PR DESCRIPTION
This allows you to set `ports = null` and `all_ports = true`.