### PR TITLE
Conditional firewall creation for backends

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ resource "google_compute_health_check" "http" {
 }
 
 resource "google_compute_firewall" "default-ilb-fw" {
+  count   = var.create_backend_firewall ? 1 : 0
   project = var.network_project == "" ? var.project : var.network_project
   name    = "${var.name}-ilb-fw"
   network = data.google_compute_network.network.name

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,9 @@ variable "connection_draining_timeout_sec" {
   default     = null
   type        = number
 }
+
+variable "create_backend_firewall" {
+  description = "Controls if firewall rules for the backends will be created or not. Health-check firewall rules are always created."
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
This allows the creation of the backend firewalls to be skipped.

Fixes https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/45