### PR TITLE
refactor default google_compute_region_backend_service timeout_sec to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 \#*\#
 .\#*
 
+# JetBrains relates files
+.idea
+
 # Vim-related files
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_compute_region_backend_service" "default" {
   name             = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
   region           = var.region
   protocol         = var.ip_protocol
-  timeout_sec      = 10
+  timeout_sec      = var.health_check["timeout_sec"]
   session_affinity = var.session_affinity
   dynamic "backend" {
     for_each = var.backends

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_compute_region_backend_service" "default" {
   name             = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
   region           = var.region
   protocol         = var.ip_protocol
-  timeout_sec      = var.health_check["timeout_sec"]
+  timeout_sec      = var.health_check["timeout_sec"] == null ? 10 : var.health_check["timeout_sec"]
   session_affinity = var.session_affinity
   dynamic "backend" {
     for_each = var.backends
@@ -128,4 +128,3 @@ resource "google_compute_firewall" "default-hc" {
   target_tags             = var.target_tags
   target_service_accounts = var.target_service_accounts
 }
-


### PR DESCRIPTION
This allows the internal load balancer health check timeout_sec to be applied to the timeout_sec of the google_compute_region_backend_service, instead of having one hardcoded value for the latter.

Fixes #53 