### PR TITLE
fix: Correct timeout value in tests to match #55

### DIFF
--- a/test/integration/minimal/controls/minimal.rb
+++ b/test/integration/minimal/controls/minimal.rb
@@ -73,8 +73,8 @@ control 'minimal' do
       expect(backend_services[0]['healthChecks'][0]).to end_with "#{resource_name_prefix}-hc-http"
     end
 
-    it 'has a timeout length of 10 seconds' do
-      expect(backend_services[0]['timeoutSec']).to eq(10)
+    it 'has a timeout length of 1 second' do
+      expect(backend_services[0]['timeoutSec']).to eq(1)
     end
   end
 end


### PR DESCRIPTION
BREAKING CHANGE: Backend service now inherits the same timeout used for health checks, instead of the former hardcoded value of 10 seconds.