### PR TITLE
Enable users to control if firewall rules for health check are created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,7 @@ resource "google_compute_firewall" "default-ilb-fw" {
 }
 
 resource "google_compute_firewall" "default-hc" {
+  count   = var.create_healtcheck_firewall ? 1 : 0
   project = var.network_project == "" ? var.project : var.network_project
   name    = "${var.name}-hc"
   network = data.google_compute_network.network.name

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "google_compute_firewall" "default-ilb-fw" {
 }
 
 resource "google_compute_firewall" "default-hc" {
-  count   = var.create_healtcheck_firewall ? 1 : 0
+  count   = var.create_health_check_firewall ? 1 : 0
   project = var.network_project == "" ? var.project : var.network_project
   name    = "${var.name}-hc"
   network = data.google_compute_network.network.name

--- a/variables.tf
+++ b/variables.tf
@@ -140,7 +140,13 @@ variable "connection_draining_timeout_sec" {
 }
 
 variable "create_backend_firewall" {
-  description = "Controls if firewall rules for the backends will be created or not. Health-check firewall rules are always created."
+  description = "Controls if firewall rules for the backends will be created or not. Health-check firewall rules are controlled separately."
+  default     = true
+  type        = bool
+}
+
+variable "create_healtcheck_firewall" {
+  description = "Controls if firewall rules for the health check will be created or not. If this rule is not present firewall healthcheck will fail."
   default     = true
   type        = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -145,7 +145,7 @@ variable "create_backend_firewall" {
   type        = bool
 }
 
-variable "create_healtcheck_firewall" {
+variable "create_health_check_firewall" {
   description = "Controls if firewall rules for the health check will be created or not. If this rule is not present backend healthcheck will fail."
   default     = true
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "create_backend_firewall" {
 }
 
 variable "create_healtcheck_firewall" {
-  description = "Controls if firewall rules for the health check will be created or not. If this rule is not present firewall healthcheck will fail."
+  description = "Controls if firewall rules for the health check will be created or not. If this rule is not present backend healthcheck will fail."
   default     = true
   type        = bool
 }


### PR DESCRIPTION
This module currently forces user to create firewall rules for health check. This PR changes that behavior adding new variable to control if firewall rules are created for health checks with default set to `true` and proper comment explaining the implications of setting it differently. 

Motivation behind opening this configuration option is scenario where load-balancer is created in shared network and project creating it doesn't have access to manipulate firewall rules.