### PR TITLE
Remove timeout_sec from google_compute_region_backend_service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,6 @@ resource "google_compute_region_backend_service" "default" {
   name                            = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
   region                          = var.region
   protocol                        = var.ip_protocol
-  timeout_sec                     = var.health_check["timeout_sec"] == null ? 10 : var.health_check["timeout_sec"]
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
   session_affinity                = var.session_affinity
   dynamic "backend" {

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_region_backend_service" "default" {
   name                            = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
   region                          = var.region
   protocol                        = var.ip_protocol
-  # Do not try to add timeout_sec, as it is has no impact. See https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/53#issuecomment-893427675S
+  # Do not try to add timeout_sec, as it is has no impact. See https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/53#issuecomment-893427675
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
   session_affinity                = var.session_affinity
   dynamic "backend" {

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "google_compute_region_backend_service" "default" {
   name                            = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
   region                          = var.region
   protocol                        = var.ip_protocol
+  # Do not try to add timeout_sec, as it is has no impact. See https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/53#issuecomment-893427675S
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
   session_affinity                = var.session_affinity
   dynamic "backend" {

--- a/main.tf
+++ b/main.tf
@@ -44,10 +44,10 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 resource "google_compute_region_backend_service" "default" {
-  project                         = var.project
-  name                            = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
-  region                          = var.region
-  protocol                        = var.ip_protocol
+  project  = var.project
+  name     = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
+  region   = var.region
+  protocol = var.ip_protocol
   # Do not try to add timeout_sec, as it is has no impact. See https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/53#issuecomment-893427675
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
   session_affinity                = var.session_affinity


### PR DESCRIPTION
Remove timeout_sec from google_compute_region_backend_service because it's ignored.
Fixes #53 