### PR TITLE
Add flexibility for LB component names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "google_compute_forwarding_rule" "default" {
 
 resource "google_compute_region_backend_service" "default" {
   project  = var.project
-  name     = var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc"
+  name     = var.bs_name == "" ? (var.health_check["type"] == "tcp" ? "${var.name}-with-tcp-hc" : "${var.name}-with-http-hc") : var.bs_name
   region   = var.region
   protocol = var.ip_protocol
   # Do not try to add timeout_sec, as it is has no impact. See https://github.com/terraform-google-modules/terraform-google-lb-internal/issues/53#issuecomment-893427675
@@ -66,7 +66,7 @@ resource "google_compute_health_check" "tcp" {
   provider = google-beta
   count    = var.health_check["type"] == "tcp" ? 1 : 0
   project  = var.project
-  name     = "${var.name}-hc-tcp"
+  name     = var.hc_name == "" ? ("${var.name}-hc-tcp") : var.hc_name
 
   timeout_sec         = var.health_check["timeout_sec"]
   check_interval_sec  = var.health_check["check_interval_sec"]
@@ -93,7 +93,7 @@ resource "google_compute_health_check" "http" {
   provider = google-beta
   count    = var.health_check["type"] == "http" ? 1 : 0
   project  = var.project
-  name     = "${var.name}-hc-http"
+  name     = var.hc_name == "" ? ("${var.name}-hc-http") : var.hc_name
 
   timeout_sec         = var.health_check["timeout_sec"]
   check_interval_sec  = var.health_check["check_interval_sec"]
@@ -120,7 +120,7 @@ resource "google_compute_health_check" "http" {
 resource "google_compute_firewall" "default-ilb-fw" {
   count   = var.create_backend_firewall ? 1 : 0
   project = var.network_project == "" ? var.project : var.network_project
-  name    = "${var.name}-ilb-fw"
+  name    = var.fw_name == "" ? ("${var.name}-ilb-fw") : var.fw_name
   network = data.google_compute_network.network.name
 
   allow {

--- a/variables.tf
+++ b/variables.tf
@@ -150,3 +150,21 @@ variable "create_health_check_firewall" {
   default     = true
   type        = bool
 }
+
+variable "bs_name" {
+  type        = string
+  description = "Backend serevice name. When variable is empty, name will be derived from health_check[\"type\"]"
+  default     = ""
+}
+
+variable "hc_name" {
+  type        = string
+  description = "Health check name. When variable is empty, name will be derived from health_check[\"type\"]"
+  default     = ""
+}
+
+variable "fw_name" {
+  type        = string
+  description = "Firewall rule name. When variable is empty, name will be derived from var.name"
+  default     = ""
+}


### PR DESCRIPTION
Current module only allows for fixed Backend service, health check and fw rule names and isn't useful when using terraform import as terraform will try to re-create the resources.

This PR offers flexibility around the naming convention.