### PR TITLE
Support the balancing_mode attribute for internal LB backends

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,9 +59,10 @@ resource "google_compute_region_backend_service" "default" {
   dynamic "backend" {
     for_each = var.backends
     content {
-      group       = lookup(backend.value, "group", null)
-      description = lookup(backend.value, "description", null)
-      failover    = lookup(backend.value, "failover", null)
+      group          = lookup(backend.value, "group", null)
+      description    = lookup(backend.value, "description", null)
+      balancing_mode = lookup(backend.value, "balancing_mode", null)
+      failover       = lookup(backend.value, "failover", null)
     }
   }
   health_checks = concat(google_compute_health_check.tcp.*.self_link, google_compute_health_check.http.*.self_link, google_compute_health_check.https.*.self_link)


### PR DESCRIPTION
At present, the `balancing_mode` defaults to `CONNECTION`. Allowing this to be configured enables this module to target backends using the `RATE` or `UTILIZATION` balancing modes.