### PR TITLE
fix: network field cannot be modified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,13 @@ resource "google_compute_region_backend_service" "default" {
     }
   }
   health_checks = concat(google_compute_health_check.tcp.*.self_link, google_compute_health_check.http.*.self_link, google_compute_health_check.https.*.self_link)
+
+  lifecycle {
+    ignore_changes = [
+      # We set network configuration only once, because network field cannot be modified.
+      network,
+    ]
+  }
 }
 
 resource "google_compute_health_check" "tcp" {


### PR DESCRIPTION
I don't know when, but around two months ago we started to get issues with internal LBs. It errored with message below whenever we do "apply":

> Error updating RegionBackendService "projects/REDACTED/regions/europe-west1/backendServices/REDACTED": googleapi: Error 400: Invalid value for field 'resource.network': 'projects/REDACTED/global/networks/REDACTED. Network field cannot be modified., invalid with module.REDACTED.google_compute_region_backend_service.default, on .terraform/modules/REDACTED/main.tf line 46, in resource "google_compute_region_backend_service" "default": 46: resource "google_compute_region_backend_service" "default" {

In terraform, the plan always shows changes in the "network" field, even though there are no new changes across all the resources of LBs we had.

```terraform
  # module.REDACTED.google_compute_region_backend_service.default will be updated in-place
  ~ resource "google_compute_region_backend_service" "default" {
        id                              = "projects/REDACTED/regions/europe-west1/backendServices/REDACTED-with-tcp-hc"
        name                            = "REDACTED-with-tcp-hc"
      + network                         = "https://www.googleapis.com/compute/v1/projects/REDACTED/global/networks/REDACTED"
        # (13 unchanged attributes hidden)
        # (1 unchanged block hidden)
    }
```

And errors have still remained the same even though we upgraded the latest version of the module.

So I believe Google API has been changed regarding the network field and cannot be modified anymore. I added a fix to this situation, but probably the best option would be to completely replace the load balancer whenever we have network changes.
