### PR TITLE
Adding option to enable logging and edit log sample rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ module "gce-ilb" {
 | ip\_protocol | The IP protocol for the backend and frontend forwarding rule. TCP or UDP. | `string` | `"TCP"` | no |
 | is\_mirroring\_collector | Indicates whether or not this load balancer can be used as a collector for packet mirroring. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL. | `bool` | `false` | no |
 | labels | The labels to attach to resources created by this module. | `map(string)` | `{}` | no |
+| log\_config | This field denotes the logging options for the load balancer traffic served by this backend service. | <pre>object({<br>    enable      = bool<br>    sample_rate = number<br>  })</pre> | <pre>{<br>  "enable": true,<br>  "sample_rate": 1<br>}</pre> | no |
 | name | Name for the forwarding rule and prefix for supporting resources. | `string` | n/a | yes |
 | network | Name of the network to create resources in. | `string` | `"default"` | no |
 | network\_project | Name of the project for the network. Useful for shared VPC. Default is var.project. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,16 @@ resource "google_compute_region_backend_service" "default" {
       balancing_mode = lookup(backend.value, "balancing_mode", "CONNECTION")
     }
   }
+
   health_checks = concat(google_compute_health_check.tcp[*].self_link, google_compute_health_check.http[*].self_link, google_compute_health_check.https[*].self_link)
+
+  dynamic "log_config" {
+    for_each = var.log_config.enable ? [1] : []
+    content {
+      enable      = var.log_config.enable
+      sample_rate = var.log_config.sample_rate
+    }
+  }
 }
 
 resource "google_compute_health_check" "tcp" {

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,12 @@ variable "is_mirroring_collector" {
   default     = false
   type        = bool
 }
+
+variable "log_config" {
+  description = "This field denotes the logging options for the load balancer traffic served by this backend service."
+  type = object({
+    enable      = bool
+    sample_rate = number
+  })
+  default = { enable = true, sample_rate = 1.0 }
+}


### PR DESCRIPTION
Add a missing logging configuration when creating Region Backend Service

<img width="498" height="128" alt="image" src="https://github.com/user-attachments/assets/19a21f21-5eaf-45f5-a4e6-c157d9be6a6d" />

https://registry.terraform.io/providers/hashicorp/google/7.11.0/docs/resources/compute_region_backend_service#log_config-3